### PR TITLE
fix(realease): Adjust versioning format for commitizen

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,6 +137,12 @@ jobs:
         with:
           token: "${{ secrets.GITHUB_TOKEN }}"
           fetch-depth: 0
+      - name: Configure commitizen
+        run: |
+          echo '[tool.commitizen]
+          tag_format = "v$major.$minor.$patch"
+          version_scheme = "semver"
+          ' > pyproject.toml
       - name: Create bump and changelog
         uses: commitizen-tools/commitizen-action@master
         with:


### PR DESCRIPTION
_Write a short description of the changes here and the motivation behind them_
Fix Build and Release Docker Image CI to release on GitHub.
## Changes:
- _List the changes introduced by this PR more in detail here_
Update CI job to tell commitizen to expect tags in the format v1.0.0.
## Types of changes

_Leave on the following list the types of changes introduced by this PR and remove
the ones that don't apply. Please also remove this line._

- Bugfix (non-breaking change which fixes an issue)

## Testing

**Requires testing** No

**In case you checked yes, did you write tests?** No

